### PR TITLE
KAFKA-10199: Fix switching to updating standbys if standby is removed (#12687)

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
@@ -84,7 +84,7 @@ public class DefaultStateUpdater implements StateUpdater {
                 .collect(Collectors.toList());
         }
 
-        public boolean onlyStandbyTasksLeft() {
+        private boolean onlyStandbyTasksUpdating() {
             return !updatingTasks.isEmpty() && updatingTasks.values().stream().noneMatch(Task::isActive);
         }
 
@@ -292,7 +292,9 @@ public class DefaultStateUpdater implements StateUpdater {
                 changelogReader.unregister(changelogPartitions);
                 removedTasks.add(task);
                 updatingTasks.remove(taskId);
-                transitToUpdateStandbysIfOnlyStandbysLeft();
+                if (task.isActive()) {
+                    transitToUpdateStandbysIfOnlyStandbysLeft();
+                }
                 log.info((task.isActive() ? "Active" : "Standby")
                     + " task " + task.id() + " was removed from the updating tasks and added to the removed tasks.");
             } else if (pausedTasks.containsKey(taskId)) {
@@ -361,7 +363,7 @@ public class DefaultStateUpdater implements StateUpdater {
         }
 
         private void transitToUpdateStandbysIfOnlyStandbysLeft() {
-            if (onlyStandbyTasksLeft()) {
+            if (onlyStandbyTasksUpdating()) {
                 changelogReader.transitToUpdateStandby();
             }
         }


### PR DESCRIPTION
When the state updater only contains standby tasks and then a
standby task is removed, an IllegalStateException is thrown
because the changelog reader does not allow to switch to standby
updating mode more than once in a row.

This commit fixes this bug by checking that the removed task is
an active one before trying to switch to standby updating mode.
If the task to remove is a standby task then either we are already
in standby updating mode and we should not switch to it again or
we are not in standby updating mode which implies that there are
still active tasks that would prevent us to switch to standby
updating mode.

Reviewer: Guozhang Wang <wangguoz@gmail.com>