### PR TITLE
KAFKA-10199: Integrate Topology Pause/Resume with StateUpdater (#12659)

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateUpdater.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateUpdater.java
@@ -95,32 +95,6 @@ public interface StateUpdater {
     void remove(final TaskId taskId);
 
     /**
-     * Pause a task (active or standby) from restoring in the state updater.
-     *
-     * This method does not block until the task is paused.
-     *
-     * Restored tasks, removed tasks and failed tasks are not paused so this action would be an no-op for them.
-     * Stateless tasks will never be paused since they are immediately added to the
-     * restored active tasks.
-     *
-     * @param taskId ID of the task to remove
-     */
-    void pause(final TaskId taskId);
-
-    /**
-     * Resume restoring a task (active or standby) in the state updater.
-     *
-     * This method does not block until the task is paused.
-     *
-     * Restored tasks, removed tasks and failed tasks are not resumed so this action would be an no-op for them.
-     * Stateless tasks will never be resumed since they are immediately added to the
-     * restored active tasks.
-     *
-     * @param taskId ID of the task to remove
-     */
-    void resume(final TaskId taskId);
-
-    /**
      * Drains the restored active tasks from the state updater.
      *
      * The returned active tasks are removed from the state updater.
@@ -171,19 +145,15 @@ public interface StateUpdater {
     Set<Task> getTasks();
 
     /**
-     * Gets active tasks that are managed by the state updater.
+     * Gets all tasks that are currently being restored inside the state updater.
      *
-     * The state updater manages all active tasks that were added with the {@link StateUpdater#add(Task)} and that have
-     * not been removed from the state updater with one of the following methods:
-     * <ul>
-     *   <li>{@link StateUpdater#drainRestoredActiveTasks(Duration)}</li>
-     *   <li>{@link StateUpdater#drainRemovedTasks()}</li>
-     *   <li>{@link StateUpdater#drainExceptionsAndFailedTasks()}</li>
-     * </ul>
+     * Tasks that have just being added into the state updater via {@link StateUpdater#add(Task)}
+     * or have restored completely or removed will not be returned; similarly tasks that have just being
+     * removed via {@link StateUpdater#remove(TaskId)} maybe returned still.
      *
-     * @return set of all tasks managed by the state updater
+     * @return set of all updating tasks inside the state updater
      */
-    Set<StreamTask> getActiveTasks();
+    Set<Task> getUpdatingTasks();
 
     /**
      * Returns if the state updater restores active tasks.

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -400,7 +400,7 @@ public class StreamThread extends Thread {
             topologyMetadata,
             adminClient,
             stateDirectory,
-            maybeCreateAndStartStateUpdater(stateUpdaterEnabled, config, changelogReader, time, clientId, threadIdx)
+            maybeCreateAndStartStateUpdater(stateUpdaterEnabled, config, changelogReader, topologyMetadata, time, clientId, threadIdx)
         );
         referenceContainer.taskManager = taskManager;
 
@@ -446,12 +446,13 @@ public class StreamThread extends Thread {
     private static StateUpdater maybeCreateAndStartStateUpdater(final boolean stateUpdaterEnabled,
                                                                 final StreamsConfig streamsConfig,
                                                                 final ChangelogReader changelogReader,
+                                                                final TopologyMetadata topologyMetadata,
                                                                 final Time time,
                                                                 final String clientId,
                                                                 final int threadIdx) {
         if (stateUpdaterEnabled) {
             final String name = clientId + "-StateUpdater-" + threadIdx;
-            final StateUpdater stateUpdater = new DefaultStateUpdater(name, streamsConfig, changelogReader, time);
+            final StateUpdater stateUpdater = new DefaultStateUpdater(name, streamsConfig, changelogReader, topologyMetadata, time);
             stateUpdater.start();
             return stateUpdater;
         } else {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskAndAction.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskAndAction.java
@@ -24,9 +24,7 @@ public class TaskAndAction {
 
     enum Action {
         ADD,
-        REMOVE,
-        PAUSE,
-        RESUME
+        REMOVE
     }
 
     private final Task task;
@@ -49,16 +47,6 @@ public class TaskAndAction {
         return new TaskAndAction(null, taskId, Action.REMOVE);
     }
 
-    public static TaskAndAction createPauseTask(final TaskId taskId) {
-        Objects.requireNonNull(taskId, "Task ID of task to pause is null!");
-        return new TaskAndAction(null, taskId, Action.PAUSE);
-    }
-
-    public static TaskAndAction createResumeTask(final TaskId taskId) {
-        Objects.requireNonNull(taskId, "Task ID of task to resume is null!");
-        return new TaskAndAction(null, taskId, Action.RESUME);
-    }
-
     public Task getTask() {
         if (action != Action.ADD) {
             throw new IllegalStateException("Action type " + action + " cannot have a task!");
@@ -67,7 +55,7 @@ public class TaskAndAction {
     }
 
     public TaskId getTaskId() {
-        if (action != Action.REMOVE && action != Action.PAUSE && action != Action.RESUME) {
+        if (action != Action.REMOVE) {
             throw new IllegalStateException("Action type " + action + " cannot have a task ID!");
         }
         return taskId;

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
@@ -49,6 +49,7 @@ import static org.apache.kafka.streams.StreamsConfig.producerPrefix;
 import static org.apache.kafka.test.StreamsTestUtils.TaskBuilder.standbyTask;
 import static org.apache.kafka.test.StreamsTestUtils.TaskBuilder.statefulTask;
 import static org.apache.kafka.test.StreamsTestUtils.TaskBuilder.statelessTask;
+import static org.apache.kafka.test.StreamsTestUtils.TopologyMetadataBuilder.unamedTopology;
 import static org.apache.kafka.test.TestUtils.waitForCondition;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -82,12 +83,15 @@ class DefaultStateUpdaterTest {
     private final static TaskId TASK_0_2 = new TaskId(0, 2);
     private final static TaskId TASK_1_0 = new TaskId(1, 0);
     private final static TaskId TASK_1_1 = new TaskId(1, 1);
+    private final static TaskId TASK_A_0_0 = new TaskId(0, 0, "A");
+    private final static TaskId TASK_B_0_0 = new TaskId(0, 0, "B");
 
     // need an auto-tick timer to work for draining with timeout
     private final Time time = new MockTime(1L);
     private final StreamsConfig config = new StreamsConfig(configProps(COMMIT_INTERVAL));
     private final ChangelogReader changelogReader = mock(ChangelogReader.class);
-    private DefaultStateUpdater stateUpdater = new DefaultStateUpdater("test-state-updater", config, changelogReader, time);
+    private final TopologyMetadata topologyMetadata = unamedTopology().build();
+    private DefaultStateUpdater stateUpdater = new DefaultStateUpdater("test-state-updater", config, changelogReader, topologyMetadata, time);
 
     @AfterEach
     public void tearDown() {
@@ -131,12 +135,10 @@ class DefaultStateUpdaterTest {
         final StreamTask statelessTask = statelessTask(TASK_0_0).inState(State.RESTORING).build();
         final StreamTask statefulTask = statefulTask(TASK_1_0, mkSet(TOPIC_PARTITION_B_0)).inState(State.RESTORING).build();
         final StandbyTask standbyTask = standbyTask(TASK_0_2, mkSet(TOPIC_PARTITION_C_0)).inState(State.RUNNING).build();
-        stateUpdater.pause(TASK_0_1);
         stateUpdater.add(statelessTask);
         stateUpdater.add(statefulTask);
         stateUpdater.remove(TASK_1_1);
         stateUpdater.add(standbyTask);
-        stateUpdater.resume(TASK_0_1);
         verifyRemovedTasks();
 
         stateUpdater.shutdown(Duration.ofMinutes(1));
@@ -147,7 +149,7 @@ class DefaultStateUpdaterTest {
     @Test
     public void shouldRemoveUpdatingTasksOnShutdown() throws Exception {
         stateUpdater.shutdown(Duration.ofMillis(Long.MAX_VALUE));
-        stateUpdater = new DefaultStateUpdater("test-state-updater", new StreamsConfig(configProps(Integer.MAX_VALUE)), changelogReader, time);
+        stateUpdater = new DefaultStateUpdater("test-state-updater", new StreamsConfig(configProps(Integer.MAX_VALUE)), changelogReader, topologyMetadata, time);
         final StreamTask activeTask = statefulTask(TASK_0_0, mkSet(TOPIC_PARTITION_A_0)).inState(State.RESTORING).build();
         final StandbyTask standbyTask = standbyTask(TASK_0_2, mkSet(TOPIC_PARTITION_C_0)).inState(State.RUNNING).build();
         when(changelogReader.completedChangelogs()).thenReturn(Collections.emptySet());
@@ -172,8 +174,8 @@ class DefaultStateUpdaterTest {
         stateUpdater.start();
         stateUpdater.add(activeTask);
         stateUpdater.add(standbyTask);
-        stateUpdater.pause(activeTask.id());
-        stateUpdater.pause(standbyTask.id());
+        verifyUpdatingTasks(activeTask, standbyTask);
+        when(topologyMetadata.isPaused(null)).thenReturn(true);
         verifyPausedTasks(activeTask, standbyTask);
         verifyRemovedTasks();
 
@@ -184,12 +186,13 @@ class DefaultStateUpdaterTest {
 
     @Test
     public void shouldRemovePausedAndUpdatingTasksOnShutdown() throws Exception {
-        final StreamTask activeTask = statefulTask(TASK_0_0, mkSet(TOPIC_PARTITION_A_0)).inState(State.RESTORING).build();
-        final StandbyTask standbyTask = standbyTask(TASK_0_1, mkSet(TOPIC_PARTITION_A_0)).inState(State.RUNNING).build();
+        final StreamTask activeTask = statefulTask(TASK_A_0_0, mkSet(TOPIC_PARTITION_A_0)).inState(State.RESTORING).build();
+        final StandbyTask standbyTask = standbyTask(TASK_B_0_0, mkSet(TOPIC_PARTITION_A_0)).inState(State.RUNNING).build();
         stateUpdater.start();
         stateUpdater.add(activeTask);
         stateUpdater.add(standbyTask);
-        stateUpdater.pause(standbyTask.id());
+        verifyUpdatingTasks(activeTask, standbyTask);
+        when(topologyMetadata.isPaused("B")).thenReturn(true);
         verifyPausedTasks(standbyTask);
         verifyUpdatingTasks(activeTask);
         verifyRemovedTasks();
@@ -457,7 +460,8 @@ class DefaultStateUpdaterTest {
             .thenReturn(false);
         stateUpdater.start();
         stateUpdater.add(task);
-        stateUpdater.pause(task.id());
+        verifyUpdatingTasks(task);
+        when(topologyMetadata.isPaused(null)).thenReturn(true);
         verifyRestoredActiveTasks();
         verifyUpdatingTasks();
         verifyExceptionsAndFailedTasks();
@@ -731,10 +735,9 @@ class DefaultStateUpdaterTest {
         stateUpdater.start();
         stateUpdater.add(task1);
         stateUpdater.add(task2);
+        verifyUpdatingTasks(task1, task2);
 
-        stateUpdater.pause(task1.id());
-        stateUpdater.pause(task2.id());
-
+        when(topologyMetadata.isPaused(null)).thenReturn(true);
         verifyPausedTasks(task1, task2);
         verifyRemovedTasks();
         verifyUpdatingTasks();
@@ -839,14 +842,15 @@ class DefaultStateUpdaterTest {
 
     @Test
     public void shouldPauseActiveTaskAndTransitToUpdateStandby() throws Exception {
-        final StreamTask task1 = statefulTask(TASK_0_0, mkSet(TOPIC_PARTITION_A_0)).inState(State.RESTORING).build();
-        final StandbyTask task2 = standbyTask(TASK_0_1, mkSet(TOPIC_PARTITION_B_0)).inState(State.RUNNING).build();
+        final StreamTask task1 = statefulTask(TASK_A_0_0, mkSet(TOPIC_PARTITION_A_0)).inState(State.RESTORING).build();
+        final StandbyTask task2 = standbyTask(TASK_B_0_0, mkSet(TOPIC_PARTITION_B_0)).inState(State.RUNNING).build();
 
         stateUpdater.start();
         stateUpdater.add(task1);
         stateUpdater.add(task2);
+        verifyUpdatingTasks(task1, task2);
 
-        stateUpdater.pause(task1.id());
+        when(topologyMetadata.isPaused("A")).thenReturn(true);
 
         verifyPausedTasks(task1);
         verifyCheckpointTasks(true, task1);
@@ -861,8 +865,9 @@ class DefaultStateUpdaterTest {
     private void shouldPauseStatefulTask(final Task task) throws Exception {
         stateUpdater.start();
         stateUpdater.add(task);
+        verifyUpdatingTasks(task);
 
-        stateUpdater.pause(task.id());
+        when(topologyMetadata.isPaused(null)).thenReturn(true);
 
         verifyPausedTasks(task);
         verifyCheckpointTasks(true, task);
@@ -875,7 +880,7 @@ class DefaultStateUpdaterTest {
     @Test
     public void shouldNotPausingNonExistTasks() throws Exception {
         stateUpdater.start();
-        stateUpdater.pause(TASK_0_0);
+        when(topologyMetadata.isPaused(null)).thenReturn(true);
 
         verifyPausedTasks();
         verifyRestoredActiveTasks();
@@ -888,15 +893,16 @@ class DefaultStateUpdaterTest {
     public void shouldNotPauseActiveStatefulTaskInRestoredActiveTasks() throws Exception {
         final StreamTask task = statefulTask(TASK_0_0, mkSet(TOPIC_PARTITION_A_0)).inState(State.RESTORING).build();
         final StreamTask controlTask = statefulTask(TASK_1_0, mkSet(TOPIC_PARTITION_B_0)).inState(State.RESTORING).build();
+
         when(changelogReader.completedChangelogs()).thenReturn(Collections.singleton(TOPIC_PARTITION_A_0));
         when(changelogReader.allChangelogsCompleted()).thenReturn(false);
         stateUpdater.start();
         stateUpdater.add(task);
         stateUpdater.add(controlTask);
         verifyRestoredActiveTasks(task);
+        verifyUpdatingTasks(controlTask);
 
-        stateUpdater.pause(task.id());
-        stateUpdater.pause(controlTask.id());
+        when(topologyMetadata.isPaused(null)).thenReturn(true);
 
         verifyPausedTasks(controlTask);
         verifyRestoredActiveTasks(task);
@@ -918,6 +924,7 @@ class DefaultStateUpdaterTest {
 
     private void shouldNotPauseTaskInFailedTasks(final Task task) throws Exception {
         final StreamTask controlTask = statefulTask(TASK_1_0, mkSet(TOPIC_PARTITION_B_0)).inState(State.RESTORING).build();
+
         final StreamsException streamsException = new StreamsException("Something happened", task.id());
         when(changelogReader.completedChangelogs()).thenReturn(Collections.emptySet());
         when(changelogReader.allChangelogsCompleted()).thenReturn(false);
@@ -934,9 +941,9 @@ class DefaultStateUpdaterTest {
         stateUpdater.add(controlTask);
         final ExceptionAndTasks expectedExceptionAndTasks = new ExceptionAndTasks(mkSet(task), streamsException);
         verifyExceptionsAndFailedTasks(expectedExceptionAndTasks);
+        verifyUpdatingTasks(controlTask);
 
-        stateUpdater.pause(task.id());
-        stateUpdater.pause(controlTask.id());
+        when(topologyMetadata.isPaused(null)).thenReturn(true);
 
         verifyPausedTasks(controlTask);
         verifyExceptionsAndFailedTasks(expectedExceptionAndTasks);
@@ -971,7 +978,7 @@ class DefaultStateUpdaterTest {
         verifyPausedTasks();
         verifyExceptionsAndFailedTasks();
 
-        stateUpdater.pause(task.id());
+        when(topologyMetadata.isPaused(null)).thenReturn(true);
 
         verifyRemovedTasks(task);
         verifyUpdatingTasks();
@@ -995,13 +1002,14 @@ class DefaultStateUpdaterTest {
     private void shouldResumeStatefulTask(final Task task) throws Exception {
         stateUpdater.start();
         stateUpdater.add(task);
+        verifyUpdatingTasks(task);
 
-        stateUpdater.pause(task.id());
+        when(topologyMetadata.isPaused(null)).thenReturn(true);
 
         verifyPausedTasks(task);
         verifyUpdatingTasks();
 
-        stateUpdater.resume(task.id());
+        when(topologyMetadata.isPaused(null)).thenReturn(false);
 
         verifyPausedTasks();
         verifyUpdatingTasks(task);
@@ -1010,7 +1018,6 @@ class DefaultStateUpdaterTest {
     @Test
     public void shouldNotResumeNonExistingTasks() throws Exception {
         stateUpdater.start();
-        stateUpdater.resume(TASK_0_0);
 
         verifyPausedTasks();
         verifyRestoredActiveTasks();
@@ -1023,6 +1030,7 @@ class DefaultStateUpdaterTest {
     public void shouldNotResumeActiveStatefulTaskInRestoredActiveTasks() throws Exception {
         final StreamTask task = statefulTask(TASK_0_0, mkSet(TOPIC_PARTITION_A_0)).inState(State.RESTORING).build();
         final StreamTask controlTask = statefulTask(TASK_1_0, mkSet(TOPIC_PARTITION_B_0)).inState(State.RESTORING).build();
+
         when(changelogReader.completedChangelogs()).thenReturn(Collections.singleton(TOPIC_PARTITION_A_0));
         when(changelogReader.allChangelogsCompleted()).thenReturn(false);
         stateUpdater.start();
@@ -1030,10 +1038,6 @@ class DefaultStateUpdaterTest {
         stateUpdater.add(controlTask);
 
         verifyRestoredActiveTasks(task);
-
-        stateUpdater.resume(task.id());
-        stateUpdater.resume(controlTask.id());
-
         verifyPausedTasks();
         verifyRestoredActiveTasks(task);
         verifyUpdatingTasks(controlTask);
@@ -1065,8 +1069,6 @@ class DefaultStateUpdaterTest {
 
         verifyRemovedTasks(task);
         verifyUpdatingTasks();
-
-        stateUpdater.resume(task.id());
 
         verifyUpdatingTasks();
     }
@@ -1102,9 +1104,6 @@ class DefaultStateUpdaterTest {
         final ExceptionAndTasks expectedExceptionAndTasks = new ExceptionAndTasks(mkSet(task), streamsException);
         verifyExceptionsAndFailedTasks(expectedExceptionAndTasks);
         verifyUpdatingTasks(controlTask);
-
-        stateUpdater.resume(task.id());
-        stateUpdater.resume(controlTask.id());
 
         verifyExceptionsAndFailedTasks(expectedExceptionAndTasks);
         verifyUpdatingTasks(controlTask);
@@ -1323,7 +1322,7 @@ class DefaultStateUpdaterTest {
     public void shouldNotAutoCheckpointTasksIfIntervalNotElapsed() {
         // we need to use a non auto-ticking timer here to control how much time elapsed exactly
         final Time time = new MockTime();
-        final DefaultStateUpdater stateUpdater = new DefaultStateUpdater("test-state-updater", config, changelogReader, time);
+        final DefaultStateUpdater stateUpdater = new DefaultStateUpdater("test-state-updater", config, changelogReader, topologyMetadata, time);
         try {
             final StreamTask task1 = statefulTask(TASK_0_0, mkSet(TOPIC_PARTITION_A_0)).inState(State.RESTORING).build();
             final StreamTask task2 = statefulTask(TASK_0_2, mkSet(TOPIC_PARTITION_B_0)).inState(State.RESTORING).build();
@@ -1478,9 +1477,9 @@ class DefaultStateUpdaterTest {
         stateUpdater.start();
         stateUpdater.add(activeTask);
         stateUpdater.add(standbyTask);
+        verifyUpdatingTasks(activeTask, standbyTask);
 
-        stateUpdater.pause(activeTask.id());
-        stateUpdater.pause(standbyTask.id());
+        when(topologyMetadata.isPaused(null)).thenReturn(true);
 
         verifyPausedTasks(activeTask, standbyTask);
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskAndActionTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskAndActionTest.java
@@ -20,13 +20,9 @@ import org.apache.kafka.streams.processor.TaskId;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.kafka.streams.processor.internals.TaskAndAction.Action.ADD;
-import static org.apache.kafka.streams.processor.internals.TaskAndAction.Action.PAUSE;
 import static org.apache.kafka.streams.processor.internals.TaskAndAction.Action.REMOVE;
-import static org.apache.kafka.streams.processor.internals.TaskAndAction.Action.RESUME;
 import static org.apache.kafka.streams.processor.internals.TaskAndAction.createAddTask;
-import static org.apache.kafka.streams.processor.internals.TaskAndAction.createPauseTask;
 import static org.apache.kafka.streams.processor.internals.TaskAndAction.createRemoveTask;
-import static org.apache.kafka.streams.processor.internals.TaskAndAction.createResumeTask;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -59,30 +55,6 @@ class TaskAndActionTest {
     }
 
     @Test
-    public void shouldCreatePauseTaskAction() {
-        final TaskId taskId = new TaskId(0, 0);
-
-        final TaskAndAction pauseTask = createPauseTask(taskId);
-
-        assertEquals(PAUSE, pauseTask.getAction());
-        assertEquals(taskId, pauseTask.getTaskId());
-        final Exception exception = assertThrows(IllegalStateException.class, pauseTask::getTask);
-        assertEquals("Action type PAUSE cannot have a task!", exception.getMessage());
-    }
-
-    @Test
-    public void shouldCreateResumeTaskAction() {
-        final TaskId taskId = new TaskId(0, 0);
-
-        final TaskAndAction pauseTask = createResumeTask(taskId);
-
-        assertEquals(RESUME, pauseTask.getAction());
-        assertEquals(taskId, pauseTask.getTaskId());
-        final Exception exception = assertThrows(IllegalStateException.class, pauseTask::getTask);
-        assertEquals("Action type RESUME cannot have a task!", exception.getMessage());
-    }
-
-    @Test
     public void shouldThrowIfAddTaskActionIsCreatedWithNullTask() {
         final Exception exception = assertThrows(NullPointerException.class, () -> createAddTask(null));
         assertTrue(exception.getMessage().contains("Task to add is null!"));
@@ -92,17 +64,5 @@ class TaskAndActionTest {
     public void shouldThrowIfRemoveTaskActionIsCreatedWithNullTaskId() {
         final Exception exception = assertThrows(NullPointerException.class, () -> createRemoveTask(null));
         assertTrue(exception.getMessage().contains("Task ID of task to remove is null!"));
-    }
-
-    @Test
-    public void shouldThrowIfPauseTaskActionIsCreatedWithNullTaskId() {
-        final Exception exception = assertThrows(NullPointerException.class, () -> createPauseTask(null));
-        assertTrue(exception.getMessage().contains("Task ID of task to pause is null!"));
-    }
-
-    @Test
-    public void shouldThrowIfResumeTaskActionIsCreatedWithNullTaskId() {
-        final Exception exception = assertThrows(NullPointerException.class, () -> createResumeTask(null));
-        assertTrue(exception.getMessage().contains("Task ID of task to resume is null!"));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/test/StreamsTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/test/StreamsTestUtils.java
@@ -31,6 +31,7 @@ import org.apache.kafka.streams.processor.internals.ProcessorStateManager;
 import org.apache.kafka.streams.processor.internals.StandbyTask;
 import org.apache.kafka.streams.processor.internals.StreamTask;
 import org.apache.kafka.streams.processor.internals.Task;
+import org.apache.kafka.streams.processor.internals.TopologyMetadata;
 import org.apache.kafka.streams.state.KeyValueIterator;
 
 import java.io.Closeable;
@@ -334,6 +335,24 @@ public final class StreamsTestUtils {
 
         public T build() {
             return task;
+        }
+    }
+
+    public static class TopologyMetadataBuilder {
+        private final TopologyMetadata topologyMetadata;
+
+        private TopologyMetadataBuilder(final TopologyMetadata topologyMetadata) {
+            this.topologyMetadata = topologyMetadata;
+        }
+
+        public static TopologyMetadataBuilder unamedTopology() {
+            final TopologyMetadata topologyMetadata = mock(TopologyMetadata.class);
+            when(topologyMetadata.isPaused(null)).thenReturn(false);
+            return new TopologyMetadataBuilder(topologyMetadata);
+        }
+
+        public TopologyMetadata build() {
+            return topologyMetadata;
         }
     }
 }


### PR DESCRIPTION
When a topology is paused / resumed, we also need to pause / resume its corresponding tasks inside state updater.

Reviewers: Guozhang Wang <wangguoz@gmail.com>