### PR TITLE
Fix ByteBufferSerializer#serialize(String, ByteBuffer) not roundtrip input with ByteBufferDeserializer#deserialize(String, byte[]) (#12704)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/serialization/ByteBufferSerializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/ByteBufferSerializer.java
@@ -21,8 +21,7 @@ import org.apache.kafka.common.utils.Utils;
 import java.nio.ByteBuffer;
 
 /**
- * ByteBufferSerializer will not change ByteBuffer's mark, position and limit.
- * And do not need to flip before call <i>serialize(String, ByteBuffer)</i>. For example:
+ * Do not need to flip before call <i>serialize(String, ByteBuffer)</i>. For example:
  *
  * <blockquote>
  * <pre>
@@ -48,8 +47,7 @@ public class ByteBufferSerializer implements Serializer<ByteBuffer> {
             }
         }
 
-        final ByteBuffer copyData = data.asReadOnlyBuffer();
-        copyData.flip();
-        return Utils.toArray(copyData);
+        data.flip();
+        return Utils.toArray(data);
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/serialization/SerializationTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/serialization/SerializationTest.java
@@ -50,7 +50,9 @@ public class SerializationTest {
             put(Float.class, Arrays.asList(5678567.12312f, -5678567.12341f));
             put(Double.class, Arrays.asList(5678567.12312d, -5678567.12341d));
             put(byte[].class, Arrays.asList("my string".getBytes()));
-            put(ByteBuffer.class, Arrays.asList(ByteBuffer.allocate(10).put("my string".getBytes())));
+            put(ByteBuffer.class, Arrays.asList(ByteBuffer.wrap("my string".getBytes()),
+                    ByteBuffer.allocate(10).put("my string".getBytes()),
+                    ByteBuffer.allocateDirect(10).put("my string".getBytes())));
             put(Bytes.class, Arrays.asList(new Bytes("my string".getBytes())));
             put(UUID.class, Arrays.asList(UUID.randomUUID()));
         }


### PR DESCRIPTION
Reviewers: Guozhang Wang <wangguoz@gmail.com>