### PR TITLE
MINOR: Fix delegation token system test (#12693)

### DIFF
--- a/tests/kafkatest/services/delegation_tokens.py
+++ b/tests/kafkatest/services/delegation_tokens.py
@@ -92,10 +92,16 @@ KafkaClient {
         for line in output_iter:
             output += line
 
-        tokenid, hmac, owner, renewers, issuedate, expirydate, maxdate = output.split()
+        parts = output.split()
+        try:
+            tokenid, hmac, owner, requester, renewers, issuedate, expirydate, maxdate = parts
+        except ValueError:
+            raise ValueError("Could not parse %s, got parts %s" % (output, parts))
+
         return {"tokenid" : tokenid,
                 "hmac" : hmac,
                 "owner" : owner,
+                "requester": requester,
                 "renewers" : renewers,
                 "issuedate" : issuedate,
                 "expirydate" :expirydate,


### PR DESCRIPTION
KIP-373 added a "token requester" field to the output of kafka-delegation-tokens.sh. The system test was failing since it was not expecting this new field. This patch adds support for this field and improves the error output if we can't parse.

Reviewers: José Armando García Sancio <jsancio@apache.org>, Manikumar Reddy <manikumar.reddy@gmail.com>