### PR TITLE
KAFKA-14270: Fix generated Kafka Streams version file name (#12700)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1942,7 +1942,7 @@ project(':streams') {
   }
 
   task createStreamsVersionFile() {
-    def receiptFile = file("$buildDir/kafka/$buildVersionFileName")
+    def receiptFile = file("$buildDir/kafka/$buildStreamsVersionFileName")
     inputs.property "commitId", commitId
     inputs.property "version", version
     outputs.file receiptFile


### PR DESCRIPTION
Kafka Streams expects a version resource at /kafka/kafka-streams-version.properties which is read by ClientMetrics. Unfortunately, the name of the generated file was wrong and thus was not copied as a resource.

Reviewer: Bruno Cadonna <cadonna@apache.org>