### PR TITLE
MINOR; Use 3.3.1 release for system test (#12714)

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -101,6 +101,7 @@ versions += [
   kafka_30: "3.0.2",
   kafka_31: "3.1.2",
   kafka_32: "3.2.3",
+  kafka_33: "3.3.1",
   lz4: "1.8.0",
   mavenArtifact: "3.8.4",
   metrics: "2.2.0",

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -66,6 +66,7 @@ RUN mkdir -p "/opt/kafka-2.8.2" && chmod a+rw /opt/kafka-2.8.2 && curl -s "$KAFK
 RUN mkdir -p "/opt/kafka-3.0.2" && chmod a+rw /opt/kafka-3.0.2 && curl -s "$KAFKA_MIRROR/kafka_2.12-3.0.2.tgz" | tar xz --strip-components=1 -C "/opt/kafka-3.0.2"
 RUN mkdir -p "/opt/kafka-3.1.2" && chmod a+rw /opt/kafka-3.1.2 && curl -s "$KAFKA_MIRROR/kafka_2.12-3.1.2.tgz" | tar xz --strip-components=1 -C "/opt/kafka-3.1.2"
 RUN mkdir -p "/opt/kafka-3.2.3" && chmod a+rw /opt/kafka-3.2.3 && curl -s "$KAFKA_MIRROR/kafka_2.12-3.2.3.tgz" | tar xz --strip-components=1 -C "/opt/kafka-3.2.3"
+RUN mkdir -p "/opt/kafka-3.3.1" && chmod a+rw /opt/kafka-3.3.1 && curl -s "$KAFKA_MIRROR/kafka_2.12-3.3.1.tgz" | tar xz --strip-components=1 -C "/opt/kafka-3.3.1"
 
 # Streams test dependencies
 RUN curl -s "$KAFKA_MIRROR/kafka-streams-0.10.0.1-test.jar" -o /opt/kafka-0.10.0.1/libs/kafka-streams-0.10.0.1-test.jar
@@ -86,6 +87,7 @@ RUN curl -s "$KAFKA_MIRROR/kafka-streams-2.8.2-test.jar" -o /opt/kafka-2.8.2/lib
 RUN curl -s "$KAFKA_MIRROR/kafka-streams-3.0.2-test.jar" -o /opt/kafka-3.0.2/libs/kafka-streams-3.0.2-test.jar
 RUN curl -s "$KAFKA_MIRROR/kafka-streams-3.1.2-test.jar" -o /opt/kafka-3.1.2/libs/kafka-streams-3.1.2-test.jar
 RUN curl -s "$KAFKA_MIRROR/kafka-streams-3.2.3-test.jar" -o /opt/kafka-3.2.3/libs/kafka-streams-3.2.3-test.jar
+RUN curl -s "$KAFKA_MIRROR/kafka-streams-3.3.1-test.jar" -o /opt/kafka-3.3.1/libs/kafka-streams-3.3.1-test.jar
 
 # The version of Kibosh to use for testing.
 # If you update this, also update vagrant/base.sh

--- a/tests/kafkatest/version.py
+++ b/tests/kafkatest/version.py
@@ -239,7 +239,8 @@ LATEST_3_2 = V_3_2_3
 
 # 3.3.x versions
 V_3_3_0 = KafkaVersion("3.3.0")
-LATEST_3_3 = V_3_3_0
+V_3_3_1 = KafkaVersion("3.3.1")
+LATEST_3_3 = V_3_3_1
 
 # 3.4.x versions
 V_3_4_0 = KafkaVersion("3.4.0")

--- a/vagrant/base.sh
+++ b/vagrant/base.sh
@@ -154,6 +154,8 @@ get_kafka 3.1.2 2.12
 chmod a+rw /opt/kafka-3.1.2
 get_kafka 3.2.3 2.12
 chmod a+rw /opt/kafka-3.2.3
+get_kafka 3.3.1 2.12
+chmod a+rw /opt/kafka-3.3.1
 
 
 # For EC2 nodes, we want to use /mnt, which should have the local disk. On local


### PR DESCRIPTION
The following files are available in https://s3-us-west-2.amazonaws.com/kafka-packages/:

kafka-streams-3.3.1-test.jar
kafka_2.12-3.3.1.tgz
kafka_2.13-3.3.1.tgz

Reviewers: Colin P. McCabe <cmccabe@apache.org>