### PR TITLE
MINOR; Add kraft controller log level in log4j prop (#12707)

### DIFF
--- a/config/log4j.properties
+++ b/config/log4j.properties
@@ -76,6 +76,11 @@ log4j.additivity.kafka.request.logger=false
 log4j.logger.kafka.network.RequestChannel$=WARN, requestAppender
 log4j.additivity.kafka.network.RequestChannel$=false
 
+# Change the line below to adjust KRaft mode controller logging
+log4j.logger.org.apache.kafka.controller=INFO, controllerAppender
+log4j.additivity.org.apache.kafka.controller=false
+
+# Change the line below to adjust ZK mode controller logging
 log4j.logger.kafka.controller=TRACE, controllerAppender
 log4j.additivity.kafka.controller=false
 

--- a/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
@@ -370,7 +370,7 @@ class BrokerToControllerRequestThread(
       debug("Controller isn't cached, looking for local metadata changes")
       controllerNodeProvider.get() match {
         case Some(controllerNode) =>
-          info(s"Recorded new controller, from now on will use broker $controllerNode")
+          info(s"Recorded new controller, from now on will use node $controllerNode")
           updateControllerAddress(controllerNode)
           metadataUpdater.setNodes(Seq(controllerNode).asJava)
         case None =>

--- a/core/src/main/scala/kafka/server/KafkaRaftServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaRaftServer.scala
@@ -47,8 +47,6 @@ import scala.jdk.CollectionConverters._
  * constructing the controller and/or broker based on the `process.roles`
  * configuration and for managing their basic lifecycle (startup and shutdown).
  *
- * Note that this server is a work in progress and we are releasing it as
- * early access in 2.8.0.
  */
 class KafkaRaftServer(
   config: KafkaConfig,


### PR DESCRIPTION
Add KRaft controller log level entry in log4j.properties, otherwise, the controller.log is empty in KRaft mode.

Reviewers: José Armando García Sancio <jsancio@apache.org>, Ismael Juma <ismael@juma.me.uk>
