### PR TITLE
Kafka Streams Threading P2: Skeleton TaskExecutor Impl (#12744)

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskExecutor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskExecutor.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals.tasks;
+
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.internals.KafkaFutureImpl;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.processor.internals.DefaultStateUpdater;
+import org.apache.kafka.streams.processor.internals.ReadOnlyTask;
+import org.apache.kafka.streams.processor.internals.StreamTask;
+import org.slf4j.Logger;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class DefaultTaskExecutor implements TaskExecutor {
+
+    private class TaskExecutorThread extends Thread {
+
+        private final AtomicBoolean isRunning = new AtomicBoolean(true);
+        private final AtomicReference<KafkaFutureImpl<StreamTask>> pauseRequested = new AtomicReference<>(null);
+
+        private final Logger log;
+
+        public TaskExecutorThread(final String name) {
+            super(name);
+            final String logPrefix = String.format("%s ", name);
+            final LogContext logContext = new LogContext(logPrefix);
+            log = logContext.logger(DefaultStateUpdater.class);
+        }
+
+        @Override
+        public void run() {
+            log.info("Task executor thread started");
+            try {
+                while (isRunning.get()) {
+                    runOnce(time.milliseconds());
+                }
+                // TODO: add exception handling
+            } finally {
+                if (currentTask != null) {
+                    unassignCurrentTask();
+                }
+
+                shutdownGate.countDown();
+                log.info("Task executor thread shutdown");
+            }
+        }
+
+        private void runOnce(final long nowMs) {
+            final KafkaFutureImpl<StreamTask> pauseFuture;
+            if ((pauseFuture = pauseRequested.getAndSet(null)) != null) {
+                final StreamTask unassignedTask = unassignCurrentTask();
+                pauseFuture.complete(unassignedTask);
+            }
+
+            if (currentTask == null) {
+                currentTask = taskManager.assignNextTask(DefaultTaskExecutor.this);
+            } else {
+                // if a task is no longer processable, ask task-manager to give it another
+                // task in the next iteration
+                if (currentTask.isProcessable(nowMs)) {
+                    currentTask.process(nowMs);
+                } else {
+                    unassignCurrentTask();
+                }
+            }
+        }
+
+        private StreamTask unassignCurrentTask() {
+            if (currentTask == null)
+                throw new IllegalStateException("Does not own any task while being ask to unassign from task manager");
+
+            // flush the task before giving it back to task manager
+            // TODO: we can add a separate function in StreamTask to just flush and not return offsets
+            currentTask.prepareCommit();
+            taskManager.unassignTask(currentTask, DefaultTaskExecutor.this);
+
+            final StreamTask retTask = currentTask;
+            currentTask = null;
+            return retTask;
+        }
+    }
+
+    private final Time time;
+    private final TaskManager taskManager;
+
+    private StreamTask currentTask = null;
+    private TaskExecutorThread taskExecutorThread = null;
+    private CountDownLatch shutdownGate;
+
+    public DefaultTaskExecutor(final TaskManager taskManager,
+                               final Time time) {
+        this.time = time;
+        this.taskManager = taskManager;
+    }
+
+    @Override
+    public void start() {
+        if (taskExecutorThread == null) {
+            taskExecutorThread = new TaskExecutorThread("task-executor");
+            taskExecutorThread.start();
+            shutdownGate = new CountDownLatch(1);
+        }
+    }
+
+    @Override
+    public void shutdown(final Duration timeout) {
+        if (taskExecutorThread != null) {
+            taskExecutorThread.isRunning.set(false);
+            taskExecutorThread.interrupt();
+            try {
+                if (!shutdownGate.await(timeout.toMillis(), TimeUnit.MILLISECONDS)) {
+                    throw new StreamsException("State updater thread did not shutdown within the timeout");
+                }
+                taskExecutorThread = null;
+            } catch (final InterruptedException ignored) {
+            }
+        }
+    }
+
+    @Override
+    public ReadOnlyTask currentTask() {
+        return currentTask != null ? new ReadOnlyTask(currentTask) : null;
+    }
+
+    @Override
+    public KafkaFuture<StreamTask> unassign() {
+        final KafkaFutureImpl<StreamTask> future = new KafkaFutureImpl<>();
+
+        if (taskExecutorThread != null) {
+            taskExecutorThread.pauseRequested.set(future);
+        } else {
+            future.complete(null);
+        }
+
+        return future;
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/TaskExecutor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/TaskExecutor.java
@@ -49,9 +49,20 @@ public interface TaskExecutor {
     /**
      * Unassign the current processing task from the task processor and give it back to the state manager.
      *
-     * The paused task must be flushed since it may be committed or closed by the task manager next.
+     * Note there is an asymmetry between assignment and unassignment between {@link TaskManager} and {@link TaskExecutor},
+     * since assigning a task from task manager to task executor is always initiated by the task executor itself, by calling
+     * {@link TaskManager#assignNextTask(TaskExecutor)},
+     * while unassigning a task and returning it to task manager could be triggered either by the task executor proactively
+     * when it finds the task not processable anymore, or by the task manager when it needs to commit / close it.
+     * This function is used for the second case, where task manager will call this function asking the task executor
+     * to give back the task.
      *
-     * This method does not block, instead a future is returned.
+     * The task must be flushed before being unassigned, since it may be committed or closed by the task manager next.
+     *
+     * This method does not block, instead a future is returned; when the task executor finishes
+     * unassigning the task this future will then complete.
+     *
+     * @return the future capturing the completion of the unassign process
      */
     KafkaFuture<StreamTask> unassign();
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/TaskManager.java
@@ -25,17 +25,18 @@ import java.util.Set;
 public interface TaskManager {
 
     /**
-     * Get the next processible active task for the requested executor. Once the task is assigned to
+     * Get the next processable active task for the requested executor. Once the task is assigned to
      * the requested task executor, it should not be assigned to any other executors until it was
      * returned to the task manager.
      *
      * @param executor the requesting {@link TaskExecutor}
+     * @return a processable active task not assigned to any other executors, or null if there is no such task available
      */
     StreamTask assignNextTask(final TaskExecutor executor);
 
     /**
      * Unassign the stream task so that it can be assigned to other executors later
-     * or be removed from the task manager. The requested executor must have locked
+     * or be removed from the task manager. The requested executor must have
      * the task already, otherwise an exception would be thrown.
      *
      * @param executor the requesting {@link TaskExecutor}

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskExecutorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskExecutorTest.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals.tasks;
+
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.streams.processor.internals.StreamTask;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class DefaultTaskExecutorTest {
+
+    private final static long VERIFICATION_TIMEOUT = 15000;
+
+    private final Time time = new MockTime(1L);
+    private final StreamTask task = mock(StreamTask.class);
+    private final TaskManager taskManager = mock(TaskManager.class);
+
+    private final DefaultTaskExecutor taskExecutor = new DefaultTaskExecutor(taskManager, time);
+
+    @BeforeEach
+    public void setUp() {
+        // only assign a task for the first time
+        when(taskManager.assignNextTask(taskExecutor)).thenReturn(task).thenReturn(null);
+        when(task.isProcessable(anyLong())).thenReturn(true);
+        when(task.process(anyLong())).thenReturn(true);
+        when(task.prepareCommit()).thenReturn(Collections.emptyMap());
+    }
+
+    @AfterEach
+    public void tearDown() {
+        taskExecutor.shutdown(Duration.ofMinutes(1));
+    }
+
+    @Test
+    public void shouldShutdownTaskExecutor() {
+        assertNull(taskExecutor.currentTask(), "Have task assigned before startup");
+
+        taskExecutor.start();
+
+        verify(taskManager, timeout(VERIFICATION_TIMEOUT)).assignNextTask(taskExecutor);
+
+        taskExecutor.shutdown(Duration.ofMinutes(1));
+
+        verify(task).prepareCommit();
+        verify(taskManager).unassignTask(task, taskExecutor);
+
+        assertNull(taskExecutor.currentTask(), "Have task assigned after shutdown");
+    }
+
+    @Test
+    public void shouldUnassignTaskWhenNotProcessable() {
+        when(task.isProcessable(anyLong())).thenReturn(false);
+
+        taskExecutor.start();
+
+        verify(taskManager, timeout(VERIFICATION_TIMEOUT)).unassignTask(task, taskExecutor);
+        verify(task).prepareCommit();
+        assertNull(taskExecutor.currentTask());
+    }
+
+    @Test
+    public void shouldUnassignTaskWhenRequired() throws Exception {
+        taskExecutor.start();
+
+        verify(taskManager, timeout(VERIFICATION_TIMEOUT)).assignNextTask(taskExecutor);
+        assertNotNull(taskExecutor.currentTask());
+
+        final KafkaFuture<StreamTask> future = taskExecutor.unassign();
+
+        verify(taskManager, timeout(VERIFICATION_TIMEOUT)).unassignTask(task, taskExecutor);
+        verify(task).prepareCommit();
+        assertNull(taskExecutor.currentTask());
+
+        assertTrue(future.isDone(), "Unassign is not completed");
+        assertEquals(task, future.get(), "Unexpected task was unassigned");
+    }
+}


### PR DESCRIPTION
0. Address comments from P1.
1. Add the DefaultTaskExecutor implementation class.
2. Related DefaultTaskExecutorTest.

Pending in future PRs: a) exception handling, primarily to send them to polling thread, b) light-weight task flushing procedure.