### PR TITLE
KAFKA-14299: Never transition to UpdateStandby twice (#12762)

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
@@ -214,7 +214,9 @@ public class DefaultStateUpdater implements StateUpdater {
         private void addToExceptionsAndFailedTasksThenRemoveFromUpdatingTasks(final ExceptionAndTasks exceptionAndTasks) {
             exceptionsAndFailedTasks.add(exceptionAndTasks);
             exceptionAndTasks.getTasks().stream().map(Task::id).forEach(updatingTasks::remove);
-            transitToUpdateStandbysIfOnlyStandbysLeft();
+            if (exceptionAndTasks.getTasks().stream().anyMatch(Task::isActive)) {
+                transitToUpdateStandbysIfOnlyStandbysLeft();
+            }
         }
 
         private void addToExceptionsAndFailedTasksThenClearUpdatingTasks(final ExceptionAndTasks exceptionAndTasks) {
@@ -310,7 +312,9 @@ public class DefaultStateUpdater implements StateUpdater {
             task.maybeCheckpoint(true);
             pausedTasks.put(taskId, task);
             updatingTasks.remove(taskId);
-            transitToUpdateStandbysIfOnlyStandbysLeft();
+            if (task.isActive()) {
+                transitToUpdateStandbysIfOnlyStandbysLeft();
+            }
             log.debug((task.isActive() ? "Active" : "Standby")
                 + " task " + task.id() + " was paused from the updating tasks and added to the paused tasks.");
         }


### PR DESCRIPTION
In two situations, the current code could transition the ChangelogReader
to UpdateStandby when already in that state, causing an IllegalStateException. 
Namely these two cases are:

1. When only standby tasks are restoring and one of them crashes.
2. When only standby tasks are restoring and one of them is paused.

This change fixes both issues by only transitioning if the paused or
failed task is an active task.

Reviewer: Bruno Cadonna <cadonna@apache.org>