### PR TITLE
MINOR: Get console output in quickstart examples (#12719)

### DIFF
--- a/streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
+++ b/streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
@@ -30,8 +30,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kafka.version>3.4.0-SNAPSHOT</kafka.version>
-        <slf4j.version>1.7.7</slf4j.version>
-        <log4j.version>1.2.17</log4j.version>
+        <slf4j.version>1.7.36</slf4j.version>
     </properties>
 
     <repositories>
@@ -126,6 +125,12 @@
     </build>
 
     <dependencies>
+        <!-- To enable console logging -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-reload4j</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
         <!-- Apache Kafka dependencies -->
         <dependency>
             <groupId>org.apache.kafka</groupId>

--- a/streams/quickstart/java/src/main/resources/archetype-resources/src/main/java/LineSplit.java
+++ b/streams/quickstart/java/src/main/resources/archetype-resources/src/main/java/LineSplit.java
@@ -35,7 +35,7 @@ import java.util.concurrent.CountDownLatch;
  */
 public class LineSplit {
 
-    public static void main(String[] args) throws Exception {
+    public static void main(String[] args) {
         Properties props = new Properties();
         props.put(StreamsConfig.APPLICATION_ID_CONFIG, "streams-linesplit");
         props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");

--- a/streams/quickstart/java/src/main/resources/archetype-resources/src/main/java/Pipe.java
+++ b/streams/quickstart/java/src/main/resources/archetype-resources/src/main/java/Pipe.java
@@ -26,13 +26,13 @@ import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 
 /**
- * In this example, we implement a simple LineSplit program using the high-level Streams DSL
+ * In this example, we implement a simple Pipe program using the high-level Streams DSL
  * that reads from a source topic "streams-plaintext-input", where the values of messages represent lines of text,
  * and writes the messages as-is into a sink topic "streams-pipe-output".
  */
 public class Pipe {
 
-    public static void main(String[] args) throws Exception {
+    public static void main(String[] args) {
         Properties props = new Properties();
         props.put(StreamsConfig.APPLICATION_ID_CONFIG, "streams-pipe");
         props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");

--- a/streams/quickstart/java/src/main/resources/archetype-resources/src/main/java/WordCount.java
+++ b/streams/quickstart/java/src/main/resources/archetype-resources/src/main/java/WordCount.java
@@ -41,7 +41,7 @@ import java.util.concurrent.CountDownLatch;
  */
 public class WordCount {
 
-    public static void main(String[] args) throws Exception {
+    public static void main(String[] args) {
         Properties props = new Properties();
         props.put(StreamsConfig.APPLICATION_ID_CONFIG, "streams-wordcount");
         props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");


### PR DESCRIPTION
Quickstart examples didn't produce any console output, since it was missing a logger implementation in the classpath.

Also some minor cleanups.

Tested by creating a test project and running the code.