### PR TITLE
MINOR: Fix usage instruction of skipSigning build parameter (#12731)

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ For backwards compatibility, the following also works:
 
 ### Installing specific projects to the local Maven repository ###
 
-    ./gradlew -PskipSigning :streams:publishToMavenLocal
+    ./gradlew -PskipSigning=true :streams:publishToMavenLocal
     
 If needed, you can specify the Scala version with `-PscalaVersion=2.13`.
 


### PR DESCRIPTION
skipSigning parameter must be set to a boolean value to work.

Reviewers: Bill Bejeck <bbejeck@apache.org>