### PR TITLE
MINOR: Add test case for topic recreation with collision chars (#12796)

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -263,6 +263,10 @@ public class ReplicationControlManager {
         public Uuid topicId() {
             return id;
         }
+
+        public int numPartitions(long epoch) {
+            return parts.size(epoch);
+        }
     }
 
     /**


### PR DESCRIPTION
This patch adds a unit test for topic recreation with colliding characters (such as `.`). This was broken up until https://github.com/apache/kafka/pull/12790. 

Reviewers: José Armando García Sancio <jsancio@users.noreply.github.com>