### PR TITLE
KAFKA-14247: add handler impl to the prototype (#12775)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThread.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThread.java
@@ -64,27 +64,6 @@ public class DefaultBackgroundThread extends KafkaThread {
     private final AtomicReference<Optional<RuntimeException>> exception =
         new AtomicReference<>(Optional.empty());
 
-    public DefaultBackgroundThread(final ConsumerConfig config,
-                                   final LogContext logContext,
-                                   final BlockingQueue<ApplicationEvent> applicationEventQueue,
-                                   final BlockingQueue<BackgroundEvent> backgroundEventQueue,
-                                   final SubscriptionState subscriptions,
-                                   final ConsumerMetadata metadata,
-                                   final ConsumerNetworkClient networkClient,
-                                   final Metrics metrics) {
-        this(
-            Time.SYSTEM,
-            config,
-            logContext,
-            applicationEventQueue,
-            backgroundEventQueue,
-            subscriptions,
-            metadata,
-            networkClient,
-            metrics
-        );
-    }
-
     public DefaultBackgroundThread(final Time time,
                                    final ConsumerConfig config,
                                    final LogContext logContext,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultEventHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultEventHandler.java
@@ -35,6 +35,7 @@ import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 
 /**
  * An {@code EventHandler} that uses a single background thread to consume {@code ApplicationEvent} and produce
@@ -46,6 +47,24 @@ public class DefaultEventHandler implements EventHandler {
     private final BlockingQueue<BackgroundEvent> backgroundEventQueue;
     private final DefaultBackgroundThread backgroundThread;
 
+    public DefaultEventHandler(final ConsumerConfig config,
+                               final LogContext logContext,
+                               final SubscriptionState subscriptionState,
+                               final ApiVersions apiVersions,
+                               final Metrics metrics,
+                               final ClusterResourceListeners clusterResourceListeners,
+                               final Sensor fetcherThrottleTimeSensor) {
+        this(Time.SYSTEM,
+                config,
+                logContext,
+                new LinkedBlockingQueue<>(),
+                new LinkedBlockingQueue<>(),
+                subscriptionState,
+                apiVersions,
+                metrics,
+                clusterResourceListeners,
+                fetcherThrottleTimeSensor);
+    }
 
     public DefaultEventHandler(final Time time,
                                final ConsumerConfig config,
@@ -95,14 +114,13 @@ public class DefaultEventHandler implements EventHandler {
             logContext
         );
         final ConsumerNetworkClient networkClient = new ConsumerNetworkClient(
-            logContext,
-            netClient,
-            metadata,
-            time,
-            config.getInt(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG),
-            config.getInt(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG),
-            config.getInt(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG)
-        );
+                logContext,
+                netClient,
+                metadata,
+                time,
+                config.getLong(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG),
+                config.getInt(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG),
+                config.getInt(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG));
         this.backgroundThread = new DefaultBackgroundThread(
             time,
             config,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
@@ -16,32 +16,135 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
+import org.apache.kafka.clients.ApiVersions;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.GroupRebalanceConfig;
 import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
+import org.apache.kafka.clients.consumer.ConsumerInterceptor;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
+import org.apache.kafka.clients.consumer.OffsetCommitCallback;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.consumer.internals.events.ApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.BackgroundEvent;
 import org.apache.kafka.clients.consumer.internals.events.EventHandler;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.internals.ClusterResourceListeners;
+import org.apache.kafka.common.metrics.KafkaMetricsContext;
+import org.apache.kafka.common.metrics.MetricConfig;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.MetricsContext;
+import org.apache.kafka.common.metrics.MetricsReporter;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
+import org.slf4j.Logger;
 
 import java.time.Duration;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.regex.Pattern;
 
 /**
- * This prototype consumer uses the EventHandler to process application events so that the network IO can be processed in a background thread. Visit
+ * This prototype consumer uses the EventHandler to process application
+ * events so that the network IO can be processed in a background thread. Visit
  * <a href="https://cwiki.apache.org/confluence/display/KAFKA/Proposal%3A+Consumer+Threading+Model+Refactor" >this document</a>
  * for detail implementation.
  */
-public abstract class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
+public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
+    private static final String CLIENT_ID_METRIC_TAG = "client-id";
+    private static final String JMX_PREFIX = "kafka.consumer";
+
+    private final LogContext logContext;
     private final EventHandler eventHandler;
     private final Time time;
+    private final Optional<String> groupId;
+    private final String clientId;
+    private final Logger log;
+    private final SubscriptionState subscriptions;
+    private final Metrics metrics;
+    private final long defaultApiTimeoutMs;
 
-    public PrototypeAsyncConsumer(final Time time, final EventHandler eventHandler) {
+    @SuppressWarnings("unchecked")
+    public PrototypeAsyncConsumer(final Time time,
+                                  final ConsumerConfig config,
+                                  final Deserializer<K> keyDeserializer,
+                                  final Deserializer<V> valueDeserializer) {
         this.time = time;
+        GroupRebalanceConfig groupRebalanceConfig = new GroupRebalanceConfig(config,
+                GroupRebalanceConfig.ProtocolType.CONSUMER);
+        this.groupId = Optional.ofNullable(groupRebalanceConfig.groupId);
+        this.clientId = config.getString(CommonClientConfigs.CLIENT_ID_CONFIG);
+        this.defaultApiTimeoutMs = config.getInt(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG);
+        // If group.instance.id is set, we will append it to the log context.
+        if (groupRebalanceConfig.groupInstanceId.isPresent()) {
+            logContext = new LogContext("[Consumer instanceId=" + groupRebalanceConfig.groupInstanceId.get() +
+                    ", clientId=" + clientId + ", groupId=" + groupId.orElse("null") + "] ");
+        } else {
+            logContext = new LogContext("[Consumer clientId=" + clientId + ", groupId=" + groupId.orElse("null") + "] ");
+        }
+        this.log = logContext.logger(getClass());
+        OffsetResetStrategy offsetResetStrategy = OffsetResetStrategy.valueOf(config.getString(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG).toUpperCase(Locale.ROOT));
+        this.subscriptions = new SubscriptionState(logContext, offsetResetStrategy);
+        this.metrics = buildMetrics(config, time, clientId);
+        List<ConsumerInterceptor<K, V>> interceptorList = (List) config.getConfiguredInstances(
+                ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG,
+                ConsumerInterceptor.class,
+                Collections.singletonMap(ConsumerConfig.CLIENT_ID_CONFIG, clientId));
+        ClusterResourceListeners clusterResourceListeners = configureClusterResourceListeners(keyDeserializer,
+                valueDeserializer, metrics.reporters(), interceptorList);
+        this.eventHandler = new DefaultEventHandler(
+                config,
+                logContext,
+                subscriptions,
+                new ApiVersions(),
+                this.metrics,
+                clusterResourceListeners,
+                null // this is coming from the fetcher, but we don't have one
+        );
+    }
+
+    // Visible for testing
+    PrototypeAsyncConsumer(
+            Time time,
+            LogContext logContext,
+            ConsumerConfig config,
+            SubscriptionState subscriptionState,
+            EventHandler eventHandler,
+            Metrics metrics,
+            ClusterResourceListeners clusterResourceListeners,
+            Optional<String> groupId,
+            String clientId,
+            int defaultApiTimeoutMs) {
+        this.time = time;
+        this.logContext = logContext;
+        this.log = logContext.logger(getClass());
+        this.subscriptions = subscriptionState;
+        this.metrics = metrics;
+        this.groupId = groupId;
+        this.defaultApiTimeoutMs = defaultApiTimeoutMs;
+        this.clientId = clientId;
         this.eventHandler = eventHandler;
     }
+
 
     /**
      * poll implementation using {@link EventHandler}.
@@ -84,11 +187,28 @@ public abstract class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
         return ConsumerRecords.empty();
     }
 
-    abstract void processEvent(BackgroundEvent backgroundEvent, Duration timeout);
+    /**
+     * Commit offsets returned on the last {@link #poll(Duration) poll()} for all the subscribed list of topics and
+     * partitions.
+     */
+    @Override
+    public void commitSync() {
+        commitSync(Duration.ofMillis(defaultApiTimeoutMs));
+    }
 
-    abstract ConsumerRecords<K, V> processFetchResults(Fetch<K, V> fetch);
+    private void processEvent(final BackgroundEvent backgroundEvent, final Duration timeout) {
+        // stubbed class
+    }
 
-    abstract Fetch<K, V> collectFetches();
+    private ConsumerRecords<K, V> processFetchResults(final Fetch<K, V> fetch) {
+        // stubbed class
+        return ConsumerRecords.empty();
+    }
+
+    private Fetch<K, V> collectFetches() {
+        // stubbed class
+        return Fetch.empty();
+    }
 
     /**
      * This method sends a commit event to the EventHandler and return.
@@ -99,8 +219,176 @@ public abstract class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
         eventHandler.add(commitEvent);
     }
 
+    @Override
+    public void commitAsync(OffsetCommitCallback callback) {
+        throw new KafkaException("method not implemented");
+    }
+
+    @Override
+    public void commitAsync(Map<TopicPartition, OffsetAndMetadata> offsets, OffsetCommitCallback callback) {
+        throw new KafkaException("method not implemented");
+    }
+
+    @Override
+    public void seek(TopicPartition partition, long offset) {
+        throw new KafkaException("method not implemented");
+    }
+
+    @Override
+    public void seek(TopicPartition partition, OffsetAndMetadata offsetAndMetadata) {
+        throw new KafkaException("method not implemented");
+    }
+
+    @Override
+    public void seekToBeginning(Collection<TopicPartition> partitions) {
+        throw new KafkaException("method not implemented");
+    }
+
+    @Override
+    public void seekToEnd(Collection<TopicPartition> partitions) {
+        throw new KafkaException("method not implemented");
+    }
+
+    @Override
+    public long position(TopicPartition partition) {
+        throw new KafkaException("method not implemented");
+    }
+
+    @Override
+    public long position(TopicPartition partition, Duration timeout) {
+        throw new KafkaException("method not implemented");
+    }
+
+    @Override
+    @Deprecated
+    public OffsetAndMetadata committed(TopicPartition partition) {
+        throw new KafkaException("method not implemented");
+    }
+
+    @Override
+    @Deprecated
+    public OffsetAndMetadata committed(TopicPartition partition, Duration timeout) {
+        throw new KafkaException("method not implemented");
+    }
+
+    @Override
+    public Map<TopicPartition, OffsetAndMetadata> committed(Set<TopicPartition> partitions) {
+        throw new KafkaException("method not implemented");
+    }
+
+    @Override
+    public Map<TopicPartition, OffsetAndMetadata> committed(Set<TopicPartition> partitions, Duration timeout) {
+        throw new KafkaException("method not implemented");
+    }
+
+    @Override
+    public Map<MetricName, ? extends Metric> metrics() {
+        throw new KafkaException("method not implemented");
+    }
+
+    @Override
+    public List<PartitionInfo> partitionsFor(String topic) {
+        throw new KafkaException("method not implemented");
+    }
+
+    @Override
+    public List<PartitionInfo> partitionsFor(String topic, Duration timeout) {
+        throw new KafkaException("method not implemented");
+    }
+
+    @Override
+    public Map<String, List<PartitionInfo>> listTopics() {
+        throw new KafkaException("method not implemented");
+    }
+
+    @Override
+    public Map<String, List<PartitionInfo>> listTopics(Duration timeout) {
+        throw new KafkaException("method not implemented");
+    }
+
+    @Override
+    public Set<TopicPartition> paused() {
+        throw new KafkaException("method not implemented");
+    }
+
+    @Override
+    public void pause(Collection<TopicPartition> partitions) {
+        throw new KafkaException("method not implemented");
+    }
+
+    @Override
+    public void resume(Collection<TopicPartition> partitions) {
+        throw new KafkaException("method not implemented");
+    }
+
+    @Override
+    public Map<TopicPartition, OffsetAndTimestamp> offsetsForTimes(Map<TopicPartition, Long> timestampsToSearch) {
+        throw new KafkaException("method not implemented");
+    }
+
+    @Override
+    public Map<TopicPartition, OffsetAndTimestamp> offsetsForTimes(Map<TopicPartition, Long> timestampsToSearch, Duration timeout) {
+        throw new KafkaException("method not implemented");
+    }
+
+    @Override
+    public Map<TopicPartition, Long> beginningOffsets(Collection<TopicPartition> partitions) {
+        throw new KafkaException("method not implemented");
+    }
+
+    @Override
+    public Map<TopicPartition, Long> beginningOffsets(Collection<TopicPartition> partitions, Duration timeout) {
+        throw new KafkaException("method not implemented");
+    }
+
+    @Override
+    public Map<TopicPartition, Long> endOffsets(Collection<TopicPartition> partitions) {
+        throw new KafkaException("method not implemented");
+    }
+
+    @Override
+    public Map<TopicPartition, Long> endOffsets(Collection<TopicPartition> partitions, Duration timeout) {
+        throw new KafkaException("method not implemented");
+    }
+
+    @Override
+    public OptionalLong currentLag(TopicPartition topicPartition) {
+        throw new KafkaException("method not implemented");
+    }
+
+    @Override
+    public ConsumerGroupMetadata groupMetadata() {
+        throw new KafkaException("method not implemented");
+    }
+
+    @Override
+    public void enforceRebalance() {
+        throw new KafkaException("method not implemented");
+    }
+
+    @Override
+    public void enforceRebalance(String reason) {
+        throw new KafkaException("method not implemented");
+    }
+
+    @Override
+    public void close() {
+        throw new KafkaException("method not implemented");
+    }
+
+    @Override
+    public void close(Duration timeout) {
+        throw new KafkaException("method not implemented");
+    }
+
+    @Override
+    public void wakeup() {
+        throw new KafkaException("method not implemented");
+    }
+
     /**
-     * This method sends a commit event to the EventHandler and waits for the event to finish.
+     * This method sends a commit event to the EventHandler and waits for
+     * the event to finish.
      *
      * @param timeout max wait time for the blocking operation.
      */
@@ -113,11 +401,73 @@ public abstract class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
         try {
             commitFuture.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
         } catch (final TimeoutException e) {
-            throw new org.apache.kafka.common.errors.TimeoutException("timeout");
+            throw new org.apache.kafka.common.errors.TimeoutException(
+                     "timeout");
         } catch (final Exception e) {
             // handle exception here
             throw new RuntimeException(e);
         }
+    }
+
+    @Override
+    public void commitSync(Map<TopicPartition, OffsetAndMetadata> offsets) {
+        throw new KafkaException("method not implemented");
+    }
+
+    @Override
+    public void commitSync(Map<TopicPartition, OffsetAndMetadata> offsets, Duration timeout) {
+        throw new KafkaException("method not implemented");
+    }
+
+    @Override
+    public Set<TopicPartition> assignment() {
+        throw new KafkaException("method not implemented");
+    }
+
+    /**
+     * Get the current subscription.  or an empty set if no such call has
+     * been made.
+     * @return The set of topics currently subscribed to
+     */
+    @Override
+    public Set<String> subscription() {
+        return Collections.unmodifiableSet(this.subscriptions.subscription());
+    }
+
+    @Override
+    public void subscribe(Collection<String> topics) {
+        throw new KafkaException("method not implemented");
+    }
+
+    @Override
+    public void subscribe(Collection<String> topics, ConsumerRebalanceListener callback) {
+        throw new KafkaException("method not implemented");
+    }
+
+    @Override
+    public void assign(Collection<TopicPartition> partitions) {
+        throw new KafkaException("method not implemented");
+    }
+
+    @Override
+    public void subscribe(Pattern pattern, ConsumerRebalanceListener callback) {
+        throw new KafkaException("method not implemented");
+    }
+
+    @Override
+    public void subscribe(Pattern pattern) {
+        throw new KafkaException("method not implemented");
+    }
+
+    @Override
+    public void unsubscribe() {
+        throw new KafkaException("method not implemented");
+    }
+
+    @Override
+    @Deprecated
+    public ConsumerRecords<K, V> poll(long timeout) {
+        throw new KafkaException("method not implemented");
     }
 
     /**
@@ -134,5 +484,35 @@ public abstract class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
         public boolean process() {
             return true;
         }
+    }
+
+    private static <K, V> ClusterResourceListeners configureClusterResourceListeners(
+            final Deserializer<K> keyDeserializer,
+            final Deserializer<V> valueDeserializer,
+            final List<?>... candidateLists) {
+        ClusterResourceListeners clusterResourceListeners = new ClusterResourceListeners();
+        for (List<?> candidateList: candidateLists)
+            clusterResourceListeners.maybeAddAll(candidateList);
+
+        clusterResourceListeners.maybeAdd(keyDeserializer);
+        clusterResourceListeners.maybeAdd(valueDeserializer);
+        return clusterResourceListeners;
+    }
+
+    private static Metrics buildMetrics(
+            final ConsumerConfig config,
+            final Time time,
+            final String clientId) {
+        Map<String, String> metricsTags = Collections.singletonMap(CLIENT_ID_METRIC_TAG, clientId);
+        MetricConfig metricConfig = new MetricConfig()
+                .samples(config.getInt(ConsumerConfig.METRICS_NUM_SAMPLES_CONFIG))
+                .timeWindow(config.getLong(ConsumerConfig.METRICS_SAMPLE_WINDOW_MS_CONFIG), TimeUnit.MILLISECONDS)
+                .recordLevel(Sensor.RecordingLevel.forName(config.getString(ConsumerConfig.METRICS_RECORDING_LEVEL_CONFIG)))
+                .tags(metricsTags);
+        List<MetricsReporter> reporters = CommonClientConfigs.metricsReporters(clientId, config);
+        MetricsContext metricsContext = new KafkaMetricsContext(
+                JMX_PREFIX,
+                config.originalsWithPrefix(CommonClientConfigs.METRICS_CONTEXT_PREFIX));
+        return new Metrics(metricConfig, reporters, time, metricsContext);
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumerTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.clients.consumer.internals.events.EventHandler;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.internals.ClusterResourceListeners;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.MockTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Collections.singleton;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.CLIENT_ID_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class PrototypeAsyncConsumerTest {
+    private Map<String, Object> properties;
+    private SubscriptionState subscriptionState;
+    private MockTime time;
+    private LogContext logContext;
+    private Metrics metrics;
+    private ClusterResourceListeners clusterResourceListeners;
+    private Optional<String> groupId;
+    private String clientId;
+    private EventHandler eventHandler;
+
+    @BeforeEach
+    public void setup() {
+        this.subscriptionState = Mockito.mock(SubscriptionState.class);
+        this.eventHandler = Mockito.mock(DefaultEventHandler.class);
+        this.logContext = new LogContext();
+        this.time = new MockTime();
+        this.metrics = new Metrics(time);
+        this.groupId = Optional.empty();
+        this.clientId = "client-1";
+        this.clusterResourceListeners = new ClusterResourceListeners();
+        this.properties = new HashMap<>();
+        this.properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
+                "localhost" +
+                ":9999");
+        this.properties.put(KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        this.properties.put(VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        this.properties.put(CLIENT_ID_CONFIG, "test-client");
+    }
+    @Test
+    public void testSubscription() {
+        this.subscriptionState =
+                new SubscriptionState(new LogContext(), OffsetResetStrategy.EARLIEST);
+        PrototypeAsyncConsumer<String, String> consumer =
+                setupConsumerWithDefault();
+        subscriptionState.subscribe(singleton("t1"),
+                new NoOpConsumerRebalanceListener());
+        assertEquals(1, consumer.subscription().size());
+    }
+
+    @Test
+    public void testUnimplementedException() {
+        PrototypeAsyncConsumer<String, String> consumer =
+                setupConsumerWithDefault();
+        assertThrows(KafkaException.class, consumer::assignment, "not implemented exception");
+    }
+
+    public PrototypeAsyncConsumer<String, String> setupConsumerWithDefault() {
+        ConsumerConfig config = new ConsumerConfig(properties);
+        return new PrototypeAsyncConsumer<>(
+                this.time,
+                this.logContext,
+                config,
+                this.subscriptionState,
+                this.eventHandler,
+                this.metrics,
+                this.clusterResourceListeners,
+                this.groupId,
+                this.clientId,
+                0);
+
+    }
+}


### PR DESCRIPTION
Minor revision for KAFKA-14247. Added how the handler is called and constructed to the prototype code path.

Reviewers: John Roesler <vvcephei@apache.org>, Kirk True <kirk@mustardgrain.com>